### PR TITLE
Fixes default button white color

### DIFF
--- a/src/allineed/allineed.scss
+++ b/src/allineed/allineed.scss
@@ -27,5 +27,5 @@
 
 // Modules
 
-@import 'modules/allineed-sidebar/ain-sidebar.scss';
-@import 'modules/allineed-panel-info/ain-panel-info.scss';
+//@import 'modules/allineed-sidebar/ain-sidebar.scss';
+//@import 'modules/allineed-panel-info/ain-panel-info.scss';

--- a/src/allineed/core/components/_buttons.scss
+++ b/src/allineed/core/components/_buttons.scss
@@ -3,7 +3,7 @@
 
 $button-border-radius: $base-elements-border-radius;
 $button-border: 1px solid $colors-base;
-$button-color: $colors-primary;
+$button-color: $colors-base;
 $button-font-size: 0.8em;
 $button-font-weight: 600px;
 $button-height: $base-texts-height;


### PR DESCRIPTION
### What does this PR do?

Changes the color on `default` buttons. I noticed in the index/demo page that the `color` on the default button was white, rendering the text not visible. It is now set to the `$colors-base` variable, rendering just _a little bit_ darker on `:hover`.